### PR TITLE
Update long descriptions

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -5,7 +5,7 @@
 title: Essential Components of Web Accessibility
 nav_title: "Components of Web Accessibility" # A short title that is used in the navigation
 lang: en   # Change "en" to the translated language shortcode
-last_updated: 2024-03-04   # Put the date of this translation YYYY-MM-DD (with month in the middle)
+last_updated: 2024-03-14   # Put the date of this translation YYYY-MM-DD (with month in the middle)
 
 # translators: # remove from the beginning of this line and the lines below: "# " (the hash sign and the space)
 # - name: "Jan Doe"   # Replace Jan Doe with translator name
@@ -36,7 +36,7 @@ footer: >
     <cite>Image by Michael Duffy, from: Essential Components of Web  Accessibility. S.L. Henry, ed. Copyright W3C <sup>®</sup> (MIT, ERCIM, Keio, Beihang). w3.org/WAI/fundamentals/components/</cite><br>
     For more information, see <a href="https://www.w3.org/WAI/about/using-wai-material/">Using WAI Materials</a>.
   </p>
-  <p><strong>Date: </strong>Updated 27 February 2018.</p>
+  <p><strong>Date: </strong>Updated 14 March 2024.</p>
   <p><strong>Editor:</strong> <a href="https://www.w3.org/People/Shawn">Shawn Lawton Henry</a>. Graphic artist: Michael Duffy.</p>
 ---
 
@@ -65,7 +65,6 @@ It provides the foundation for understanding the different accessibility standar
 {% include_cached toc.html type="end" %}
 {:/}
 
-
 ## Introduction {#intro}
 {:.no_toc}
 
@@ -83,8 +82,8 @@ It is essential that several different components of web development and interac
 
 ## How the Components Relate {#relate}
 
-{% assign example_url = "/fundamentals/components/examples/#relate" | relative_url %}
-![illustration showing how components relate, detailed description at {{ example_url }}]({{ "/content-images/wai-components/relate.png" | relative_url }}){:longdesc="{{example_url}}"}
+{% assign longdesc_url = "/fundamentals/components/examples/#relate" | relative_url %}
+{% include image.html src="relate.png" alt="Illustration showing how components relate" longdesc=longdesc_url %}
 
 Web **developers** usually use **authoring tools** and evaluation tools to create web **content**.
 
@@ -107,8 +106,7 @@ There are significant interdependencies between the components; that is, the com
 
 When accessibility features are effectively implemented in one component, the other components are more likely to implement them.
 
-{% assign example_url = "/fundamentals/components/examples/#cycle" | relative_url %}
-![illustration of implementation cycle, detailed description at {{ example_url }}]({{ "/content-images/wai-components/cycle.png" | relative_url }}){:longdesc="{{example_url}}"}
+{% include image.html src="cycle.png" alt="" %}
 
 - When **web browsers, media players, assistive technologies, and other user agents** support an accessibility feature, users are more likely to demand it and developers are more likely to implement it in their **content**. 
 - When developers want to implement an accessibility feature in their **content**, they are more likely to demand that their **authoring tool** make it easy to implement. 
@@ -119,9 +117,8 @@ When accessibility features are effectively implemented in one component, the ot
 
 If an accessibility feature is not implemented in one component, there is little motivation for the other components to implement it when it does not result in an accessible user experience. For example, developers are unlikely to implement an accessibility feature that authoring tools do not support and that most browsers or assistive technologies do not implement consistently.
 
-{% assign example_url = "/fundamentals/components/examples/#weak" | relative_url %}
-![illustration of what happens when one component is weak, detailed
-description at {{ example_url }}]({{ "/content-images/wai-components/bridge.png" | relative_url }}){:longdesc="{{example_url}}"}
+{% assign longdesc_url = "/fundamentals/components/examples/#weak" | relative_url %}
+{% include image.html src="bridge.png" alt="Illustration of what happens when one component is weak" longdesc=longdesc_url %}
 
 If one component has poor accessibility support, sometimes other components can compensate through "work-arounds" that require much more effort and are not good for accessibility overall. For example,
 
@@ -143,7 +140,7 @@ These accessibility guidelines are based on the fundamental technical specificat
 
 * [ARIA, the Accessible Rich Internet Applications](/standards-guidelines/aria/) Suite, which defines a way to make web applications more accessible to people with disabilities. It especially helps with dynamic content and advanced user interface controls developed with Ajax, HTML, JavaScript, and related technologies.
 
-{% assign example_url = "/fundamentals/components/examples/#guide" | relative_url %}
-![illustration showing the guidelines for the different components, detailed description at {{ example_url }}]({{ "/content-images/wai-components/specs.png" | relative_url }}){:longdesc="{{example_url}}"}
+{% assign longdesc_url = "/fundamentals/components/examples/#guide" | relative_url %}
+{% include image.html src="specs.png" alt="Illustration showing the guidelines for the different components" longdesc=longdesc_url %}
 
 For more information, see [[W3C Accessibility Standards Overview]](/standards-guidelines/).

--- a/content/wai-components-example.md
+++ b/content/wai-components-example.md
@@ -5,7 +5,7 @@
 title: Descriptions of Essential Components of Web Accessibility Illustrations
 nav_title: Illustration Descriptions
 lang: en  # Change "en" to the translated language shortcode
-last_updated: 2024-03-07  # Put the date of this translation YYYY-MM-DD (with month in the middle)
+last_updated: 2024-03-14  # Put the date of this translation YYYY-MM-DD (with month in the middle)
 
 # translators: # remove from the beginning of this line and the lines below: "# " (the hash sign and the space)
 # - name: "Jan Doe"   # Replace Jan Doe with translator name
@@ -37,31 +37,23 @@ parent: /fundamentals/components/ # Do not change this
 {% include_cached toc.html type="end" %}
 {:/}
 
-This page describes the illustrations in the “[[Essential Components of Web Accessibility]](/standards/components/)” document and the [Essential Components of Web Accessibility Slides](http://www.w3.org/WAI/intro/components-slides).
+This page describes the illustrations in the “[[Essential Components of Web Accessibility]](/fundamentals/components/)” document and the [Essential Components of Web Accessibility Slides](https://www.w3.org/WAI/intro/components-slides).
 
 ## How the Components Relate Illustration Description {#relate}
 
-![Illustration showing How Components Relate]({{ "/content-images/wai-components/relate.png" | relative_url }})
+{% include image.html src="relate.png" alt="Illustration showing how components relate" %}
 
 Illustration with labeled graphics of boxes, content, and people. at the top center is a pie chart, an image, a form, and text, labeled “content”. coming up from the bottom left, a line connects “developers” through “authoring tools” and “evaluation tools” to “content” at the top. coming up from the bottom right, a line connects “users” to “browsers, media players” and “assistive technologies” to “content” at the top.
 
-## The Implementation Cycle Illustration Description {#cycle}
-
-![Illustration showing the Implementation Cycle]({{ "/content-images/wai-components/cycle.png" | relative_url }})
-
-Illustration with arrow going from content at the top through authoring tools at left to content at the bottom, and an arrow going from the content at the bottom through assistive technologies and user agents at the right and back to content at the top.
-
 ## When One Component is Weak Illustration Description {#weak}
 
-![Illustration showing what happens when one component is
-weak]({{ "/content-images/wai-components/bridge.png" | relative_url }})
+{% include image.html src="bridge.png" alt="Illustration of what happens when one component is weak" %}
 
 Illustration with labeled graphics of boxes, content, and people. at the top center is a pie chart, an image, a form, and text, labeled “content”. coming up from the bottom left, a line connects “developers” to “content” at the top by going around “authoring tools”. coming up from the bottom right, a line connects “users” and “content” at the top by going through multiple “browsers, media players” and “assistive technologies”.
 
 ## Guidelines for Different Components Illustration Description {#guide}
 
-![Illustration showing the different guidelines for the different
-components]({{ "/content-images/wai-components/specs.png" | relative_url }})
+{% include image.html src="specs.png" alt="Illustration showing the guidelines for the different components" %}
 
 Illustration with labeled graphics of boxes, content, and people. at the top center is a pie chart, an image, a form, and text, labeled “content”. coming up from the bottom left, a line connects “developers” through “authoring tools” and “evaluation tools” to “content” at the top. coming up from the bottom right, an arrow connects “users” to “browsers, media players” and “assistive technologies” to “content” at the top. below these are “accessibility guidelines” which include “ATAG” with an arrow pointing to “authoring tools” and “evaluation tools”, “WCAG” pointing to “content”, and “UAAG” pointing to “browsers, media players” and “assistive technologies”. at the very bottom, “technical specifications (HTML, ARIA, CSS, SVG, SMIL, etc.)” forms a base with an arrow pointing up to the accessibility guidelines.
 
@@ -71,8 +63,7 @@ Illustration with labeled graphics of boxes, content, and people. at the top cen
 
 ## Interdependencies Between Components, Example Illustration Description {#example-alt}
 
-![Illustration showing examples of how components
-relate.]({{ "/content-images/wai-components/relate-example.jpg" | relative_url }})
+{% include image.html src="relate-example.jpg" alt="Illustration showing examples of how components relate" %}
 
 Illustration with labeled graphics of boxes, content, and people. at the top center "content" and underneath it is a logo and a box with: `<img src="WAI-logo.png" alt="Web Accessibility Initiative logo">`. coming up from the bottom left, a line connects “developers” through “authoring tools” and “evaluation tools” to “content” at the top. between the “developer” and “authoring tools” is a dialog box titled: Image Tag Accessibility Attributes, a field titled: Alternative Text filled in with: Web Accessibility Initiative logo. coming up from the bottom right, a line connects “users” to “browsers, media players” and “assistive technologies” to “content” at the top. just up from the “user” is a speech bubble saying: Web Accessibility Initiative logo and a yellow box with: Web Accessibility Initiative logo. at the bottom is: `1.1 Provide a text equivalent for every non-text element` 
 


### PR DESCRIPTION
Direct link to preview: https://deploy-preview-37--wai-components.netlify.app/

Applies [WCAG 2 Technique G73](https://www.w3.org/WAI/WCAG22/Techniques/general/G73) for long descriptions: 
- A link is added underneath each image, pointing to the long description in another page.
- The link simply states "Long description of image"
- The Image component has been updated to support this: https://github.com/w3c/wai-website-theme/pull/76
- As agreed with @shawna-slh, the "Implementation cycle" image does not need an alternative text nor a long description, because its content is redundant with the text below. An empty alt attribute is used.

Resolves https://github.com/w3c/wai-components/issues/33